### PR TITLE
Support Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 - **Go Library**: Import `vpeak` into your Go projects to generate speech programmatically.
 
 ---
+## Handling Audio Files: Platform Differences
+
+### About audio files (.wav)
+
+The behavior of audio file handling depends on the options provided:
+
+- **On macOS**: Temporary `.wav` files are automatically deleted after playback unless explicitly preserved using the `-silent`, `-o`, or `-d` options.
+- **On Windows**: `.wav` files are never automatically deleted after playback, ensuring compatibility with Windows' file handling.
+You may need to manually delete the files after playback if you don't want them to persist.
+---
 ## CLI Usage
 
 ### Installation

--- a/vpeak.go
+++ b/vpeak.go
@@ -7,12 +7,24 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
+var VoicepeakPath string
+
+func init() {
+	if runtime.GOOS == "darwin" {
+		VoicepeakPath = "/Applications/voicepeak.app/Contents/MacOS/voicepeak"
+	} else if runtime.GOOS == "windows" {
+		VoicepeakPath = "C:\\Program Files\\VOICEPEAK\\voicepeak.exe"
+	} else {
+		log.Fatal("Unsupported operating system")
+	}
+}
+
 const (
-	VoicepeakPath = "/Applications/voicepeak.app/Contents/MacOS/voicepeak"
-	WavName       = "output.wav"
+	WavName = "output.wav"
 )
 
 var (
@@ -72,7 +84,15 @@ func GenerateSpeech(text string, opts Options) error {
 
 // PlayAudio plays the specified audio file
 func PlayAudio(wavName string) error {
-	cmd := exec.Command("afplay", wavName)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("afplay", wavName)
+	} else if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "start", "", wavName)
+	} else {
+		return fmt.Errorf("unsupported operating system")
+	}
+
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("wav file play failed: %v", err)
 	}

--- a/vpeak.go
+++ b/vpeak.go
@@ -72,7 +72,7 @@ func GenerateSpeech(text string, opts Options) error {
 		}
 
 		// if the output is not specified, delete the generated wav file
-		if output == WavName {
+		if runtime.GOOS != "windows" && output == WavName {
 			if err := os.Remove(WavName); err != nil {
 				return fmt.Errorf("failed to delete %s: %v", WavName, err)
 			}


### PR DESCRIPTION
## **Summary of Changes**

* Support Windows

### Note
This update includes changes to both the README and the source code to clarify and handle platform-specific behavior for audio file deletion:

1. **Source Code Updates**:
   - Modified the `GenerateSpeech` function to ensure `.wav` files are not automatically deleted on **Windows**, regardless of the presence of options like `-silent` or `-o`. This change ensures compatibility with how Windows handles file operations during playback.

2. **README Updates**:
   - Added a new section titled **Handling Audio Files: Platform Differences** to explain the differences in audio file behavior between macOS and Windows.
     - On **macOS**, temporary `.wav` files are automatically deleted unless preserved via options like `-silent`, `-o`, or `-d`.
     - On **Windows**, `.wav` files are not automatically deleted to prevent issues caused by platform-specific file handling behavior.

These changes aim to improve clarity for users and ensure consistent behavior across platforms.

## issue
https://github.com/shinshin86/vpeak/issues/1