### PR TITLE
Extend emotion option to support custom values and multiple entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,15 @@ func main() {
   - `m2`: Japanese Male 2
   - `m3`: Japanese Male 3
   - `c`:  Japanese Female Child
-- `Emotion`: Choose the emotion. Available options:
+- `Emotion`: Specify emotion values (`0`–`100`) for the following emotions:
   - `happy`
   - `fun`
   - `angry`
   - `sad`
+  - Multiple emotions can be specified using commas. Example:
+    - `happy`
+    - `happy=50`
+    - `happy=40,fun=60`
   - If no option is specified, it will be `natural`.
 - `Output`: Specify the output file path. If not set, defaults to `output.wav`.
 - `Silent`: Set to `true` to disable voice playback.

--- a/vpeak.go
+++ b/vpeak.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"strconv"
 )
 
 var VoicepeakPath string
@@ -37,12 +38,6 @@ var (
 		"m3": "Japanese Male 3",
 		"c":  "Japanese Female Child",
 	}
-	emotionMap = map[string]string{
-		"happy": "happy=100",
-		"fun":   "fun=100",
-		"angry": "angry=100",
-		"sad":   "sad=100",
-	}
 )
 
 // Options struct holds the settings for speech generation
@@ -53,6 +48,31 @@ type Options struct {
 	Silent   bool
 	Speed    *int
 	Pitch    *int
+}
+
+type Emotion struct {
+	Happy int
+	Sad   int
+	Angry int
+	Fun   int
+}
+
+func (e Emotion) String() string {
+	values := map[string]int{
+		"happy": e.Happy,
+		"sad":   e.Sad,
+		"angry": e.Angry,
+		"fun":   e.Fun,
+	}
+
+	var parts []string
+	for k, v := range values {
+		if v != 0 {
+			parts = append(parts, fmt.Sprintf("%s=%d", k, v))
+		}
+	}
+
+	return strings.Join(parts, ",")
 }
 
 // GenerateSpeech generates speech audio from the given text and options
@@ -138,6 +158,43 @@ func ProcessTextFiles(dir string, opts Options) error {
 	return nil
 }
 
+// ParseEmotion validates and normalizes an emotion option string.
+func ParseEmotion(s string) (Emotion, error) {
+	var e Emotion
+	if s == "" {
+		return e, nil
+	}
+
+	for _, p := range strings.Split(s, ",") {
+		kv := strings.SplitN(p, "=", 2)
+		name := kv[0]
+
+		val := 100
+		if len(kv) == 2 {
+			v, err := strconv.Atoi(kv[1])
+			if err != nil || v < 0 || v > 100 {
+				return e, fmt.Errorf("invalid value: %s", kv[1])
+			}
+			val = v
+		}
+
+		switch name {
+		case "happy":
+			e.Happy = val
+		case "sad":
+			e.Sad = val
+		case "angry":
+			e.Angry = val
+		case "fun":
+			e.Fun = val
+		default:
+			return e, fmt.Errorf("invalid emotion: %s", name)
+		}
+	}
+
+	return e, nil
+}
+
 func vpCmd(options []string) *exec.Cmd {
 	_, err := exec.LookPath(VoicepeakPath)
 	if err != nil {
@@ -161,11 +218,11 @@ func buildOptions(text string, opts Options) []string {
 		log.Fatalf("Invalid narrator option: %s", opts.Narrator)
 	}
 
-	if emotion, ok := emotionMap[opts.Emotion]; ok {
-		options = append([]string{"--emotion", emotion}, options...)
-	} else if opts.Emotion != "" {
+	emotion, err := ParseEmotion(opts.Emotion)
+	if err != nil {
 		log.Fatalf("Invalid emotion option: %s", opts.Emotion)
 	}
+	options = append([]string{"--emotion", emotion.String()}, options...)
 
 	if opts.Output != "" {
 		options = append([]string{"-o", opts.Output}, options...)

--- a/vpeak.go
+++ b/vpeak.go
@@ -75,6 +75,10 @@ func (e Emotion) String() string {
 	return strings.Join(parts, ",")
 }
 
+func (e Emotion) IsZero() bool {
+	return e.Happy == 0 && e.Sad == 0 && e.Angry == 0 && e.Fun == 0
+}
+
 // GenerateSpeech generates speech audio from the given text and options
 func GenerateSpeech(text string, opts Options) error {
 	options := buildOptions(text, opts)
@@ -222,7 +226,9 @@ func buildOptions(text string, opts Options) []string {
 	if err != nil {
 		log.Fatalf("Invalid emotion option: %s", opts.Emotion)
 	}
-	options = append([]string{"--emotion", emotion.String()}, options...)
+	if !emotion.IsZero() {
+		options = append([]string{"--emotion", emotion.String()}, options...)
+	}
 
 	if opts.Output != "" {
 		options = append([]string{"-o", opts.Output}, options...)


### PR DESCRIPTION
Currently emotion parameters such as `happy`, `sad`, etc. are effectively treated as boolean values.

VOICEPEAK itself supports continuous emotion values (0–100), so this change allows arbitrary values to be passed through instead of forcing them to 0 or 100. It also allows multiple emotions to be specified at once (e.g. `happy=40,fun=60`).

The existing usage (`happy` without a value) is preserved and still maps to the maximum value.

vpeakserver may need a small update to support this change.