### PR TITLE
fix: validate emotions without per-call --list-emotion and restore normalization

### DIFF
--- a/vpeak.go
+++ b/vpeak.go
@@ -89,7 +89,8 @@ func GenerateSpeech(text string, opts Options) error {
 
 	cmd1 := vpCmd(options)
 	if err := cmd1.Run(); err != nil {
-		return fmt.Errorf("voicepeak command failed: %v", err)
+		return fmt.Errorf("voicepeak command failed: %w "+
+			"(check that the specified narrator and emotion names are supported by VOICEPEAK)", err)
 	}
 
 	if !opts.Silent {
@@ -260,6 +261,55 @@ func ValidateEmotionExpression(raw string, allowed []string) (string, error) {
 	return raw, nil
 }
 
+// normalizeEmotionExpression validates an emotion expression syntactically and
+// returns it in a canonical form. Any emotion name is accepted so that character
+// products with their own emotions work; whether the name is actually supported
+// is left to VOICEPEAK. Bare names are expanded to "name=100" and zero-weighted
+// emotions are dropped, matching the previous Emotion.String behavior.
+func normalizeEmotionExpression(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+
+	var parts []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return "", fmt.Errorf("empty emotion segment")
+		}
+
+		name, value, hasValue := strings.Cut(part, "=")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return "", fmt.Errorf("empty emotion name")
+		}
+
+		weight := 100
+		if hasValue {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				return "", fmt.Errorf("empty emotion value for %s", name)
+			}
+			w, err := strconv.Atoi(value)
+			if err != nil {
+				return "", fmt.Errorf("invalid emotion weight for %s: %w", name, err)
+			}
+			if w < 0 || w > 100 {
+				return "", fmt.Errorf("emotion weight for %s must be between 0 and 100", name)
+			}
+			weight = w
+		}
+
+		if weight == 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s=%d", name, weight))
+	}
+
+	return strings.Join(parts, ","), nil
+}
+
 func voicepeakList(args ...string) ([]string, error) {
 	cmd := vpCmd(args)
 	output, err := cmd.CombinedOutput()
@@ -316,20 +366,13 @@ func buildOptions(text string, opts Options) []string {
 	}
 
 	if opts.Emotion != "" {
-		emotion := strings.TrimSpace(opts.Emotion)
-		if narrator != "" {
-			allowed, err := ListEmotions(narrator)
-			if err != nil {
-				log.Fatalf("Failed to list emotions for narrator %q: %v", narrator, err)
-			}
-			if _, err := ValidateEmotionExpression(emotion, allowed); err != nil {
-				log.Fatalf("Invalid emotion option: %s", opts.Emotion)
-			}
-		} else if _, err := ParseEmotion(emotion); err != nil {
+		emotion, err := normalizeEmotionExpression(opts.Emotion)
+		if err != nil {
 			log.Fatalf("Invalid emotion option: %s", opts.Emotion)
 		}
-
-		options = append([]string{"--emotion", emotion}, options...)
+		if emotion != "" {
+			options = append([]string{"--emotion", emotion}, options...)
+		}
 	}
 
 	if opts.Output != "" {

--- a/vpeak_test.go
+++ b/vpeak_test.go
@@ -162,3 +162,88 @@ Zundamon
 		}
 	}
 }
+
+func TestNormalizeEmotionExpression(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"empty", "", "", false},
+		{"bare name expands to 100", "happy", "happy=100", false},
+		{"dynamic bare name expands to 100", "amaama", "amaama=100", false},
+		{"explicit value kept", "happy=50", "happy=50", false},
+		{"multiple", "happy=40,fun=60", "happy=40,fun=60", false},
+		{"dynamic names kept", "amaama=40,live=60", "amaama=40,live=60", false},
+		{"input order preserved", "sad=10,happy=20", "sad=10,happy=20", false},
+		{"trim outer whitespace", " amaama=40,live=60 ", "amaama=40,live=60", false},
+		{"zero dropped", "happy=0", "", false},
+		{"zero dropped among others", "happy=0,fun=60", "fun=60", false},
+		{"max", "happy=100", "happy=100", false},
+		{"empty value", "happy=", "", true},
+		{"empty segment", "happy=50,,fun=50", "", true},
+		{"leading comma", ",happy=50", "", true},
+		{"trailing comma", "happy=50,", "", true},
+		{"non integer", "happy=foo", "", true},
+		{"negative", "happy=-1", "", true},
+		{"too high", "happy=101", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeEmotionExpression(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeEmotionExpression(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeEmotionExpression(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildOptionsEmotion(t *testing.T) {
+	flagValue := func(opts []string, flag string) (string, bool) {
+		for i, o := range opts {
+			if o == flag && i+1 < len(opts) {
+				return opts[i+1], true
+			}
+		}
+		return "", false
+	}
+
+	t.Run("bare emotion expands to 100", func(t *testing.T) {
+		opts := buildOptions("hi", Options{Narrator: "f1", Emotion: "happy"})
+		if v, _ := flagValue(opts, "--narrator"); v != "Japanese Female 1" {
+			t.Fatalf("--narrator = %q, want %q", v, "Japanese Female 1")
+		}
+		if v, _ := flagValue(opts, "--emotion"); v != "happy=100" {
+			t.Fatalf("--emotion = %q, want %q", v, "happy=100")
+		}
+	})
+
+	t.Run("dynamic emotion names pass through", func(t *testing.T) {
+		opts := buildOptions("hi", Options{Narrator: "Zundamon", Emotion: "amaama=40,live=60"})
+		if v, _ := flagValue(opts, "--narrator"); v != "Zundamon" {
+			t.Fatalf("--narrator = %q, want %q", v, "Zundamon")
+		}
+		if v, _ := flagValue(opts, "--emotion"); v != "amaama=40,live=60" {
+			t.Fatalf("--emotion = %q, want %q", v, "amaama=40,live=60")
+		}
+	})
+
+	t.Run("all-zero emotion omits --emotion", func(t *testing.T) {
+		opts := buildOptions("hi", Options{Narrator: "f1", Emotion: "happy=0"})
+		if _, ok := flagValue(opts, "--emotion"); ok {
+			t.Fatalf("--emotion should be omitted for all-zero emotion, got %v", opts)
+		}
+	})
+
+	t.Run("no emotion omits --emotion", func(t *testing.T) {
+		opts := buildOptions("hi", Options{Narrator: "f1"})
+		if _, ok := flagValue(opts, "--emotion"); ok {
+			t.Fatalf("--emotion should be omitted when no emotion given, got %v", opts)
+		}
+	})
+}


### PR DESCRIPTION
## Overview

Building on the dynamic narrator/emotion support merged in #11, this PR adjusts the cost and normalization around emotion handling. The dynamic support (arbitrary narrator/emotion names) is fully preserved.

## Changes

- **Remove the per-call `--list-emotion` invocation**
  `buildOptions` was launching `voicepeak --list-emotion <narrator>` on every emotion-bearing call, which added non-negligible overhead in batch processing (measured at ~+19.5s per 100 files locally). Syntactic validation is sufficient, so this no longer spawns an external process. `ListEmotions()` itself is kept as a public function.
- **Restore emotion-string normalization**
  Adds `normalizeEmotionExpression()`, which re-introduces expansion of bare names (`happy` → `happy=100`) and dropping of zero-weighted emotions, while still accepting arbitrary emotion names (e.g. emotions specific to character products). Values are still constrained to 0–100, as before.
- **Friendlier error on invalid input**
  An invalid narrator or emotion name causes VOICEPEAK to abort (exit 134) with an unclear cause, so `GenerateSpeech` now appends the hint `(check that the specified narrator and emotion names are supported by VOICEPEAK)` to the error.

## Backward compatibility

- No public APIs are changed or removed.
- Existing valid usage (`happy` / `happy=50` / `happy=40,fun=60`, short aliases `f1`–`c`, etc.) produces identical results.

## Verification

- `go test ./...` (added `TestNormalizeEmotionExpression` and `TestBuildOptionsEmotion`; all existing tests pass)
- Verified with the local VOICEPEAK CLI: success cases (bare emotion, multiple emotions, all-zero omission) and failure cases (invalid narrator, out-of-range value)